### PR TITLE
log messages from printer

### DIFF
--- a/mecode/printer.py
+++ b/mecode/printer.py
@@ -389,6 +389,8 @@ class Printer(object):
                     full_resp = ''
                 if 'start' in line:
                     self.responses.append(line)
+                if line.startswith('echo:'):
+                    logger.info(line.rstrip()[len('echo:'):])
             else:  # if no printer is attached, wait 10ms to check again.
                 sleep(0.01)
 


### PR DESCRIPTION
my ender 3 sends replies starting with "echo:" to indicate informative user messages.

this change passes these on to the logger object with a log level of 'info' so a user can see them if desired.